### PR TITLE
Prepare the repo for publishing the Node-API libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,11 @@
+> [!NOTE]  
+> The instructions below detail how to get started developing NativeScript's V8-based iOS runtime, `@nativescript/ios`.
+>
+> If you are interested in building the standalone Node-API libraries, instructions for those can be found as follows:
+>
+> - `@nativescript/ios-node-api`: [packages/ios/README.md](packages/ios/README.md)
+> - `@nativescript/macos-node-api`: [packages/macos/README.md](packages/macos/README.md)
+
 # Getting Started
 
 **Prerequisites**:

--- a/packages/ios/README.md
+++ b/packages/ios/README.md
@@ -17,3 +17,31 @@ Next, embed the xcframework provided at `build/ios-universal/NativeScript.xcfram
 ## Usage
 
 Until we have some example projects to provide, a few example usages in an Expo app are shown in this [tweet](https://x.com/birch_js/status/1773401773266604240).
+
+## Contributing
+
+To build `@nativescript/ios-node-api` for yourself:
+
+```sh
+git clone git@github.com:NativeScript/napi-ios.git
+cd napi-ios
+npm install
+
+# This script does the following:
+# 1. Builds the metadata generator, which consists of the following steps:
+#    - Download LLVM
+#    - Inside ./metadata-generator, run cmake to produce:
+#      - ./metadata-generator/dist/arm64/bin/objc-metadata-generator
+#      - ./metadata-generator/dist/x86_64/bin/objc-metadata-generator
+# 2. Generates metadata for iOS and macOS:
+#    - ./metadata-generator/metadata/metadata.ios.arm64.{h,nsmd}
+#    - ./metadata-generator/metadata/metadata.ios-sim.{arm64,x86_64}.{h,nsmd}
+#    - ./metadata-generator/metadata/metadata.macos.{arm64,x86_64}.{h,nsmd}
+# 3. Builds the NativeScript iOS XCFramework:
+#    - ./packages/ios/build/RelWithDebInfo/NativeScript.apple.node
+# 4. Builds the NativeScript macOS XCFramework:
+#    - ./packages/macos/build/RelWithDebInfo/NativeScript.apple.node
+./build_all_react_native.sh
+```
+
+Currently, we are following a convention of committing most, if not all, of these build files to source, so you may find that it's ready set up to begin with.

--- a/packages/ios/package.json
+++ b/packages/ios/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nativescript/ios-node-api",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "description": "An embeddable, engine-agnostic NativeScript runtime for iOS based on Node-API",
   "repository": {
     "type": "git",

--- a/packages/ios/package.json
+++ b/packages/ios/package.json
@@ -15,8 +15,7 @@
     "types"
   ],
   "scripts": {
-    "build": "deno task build",
-    "prepublishOnly": "rimraf build && npm run build"
+    "build": "cd ../.. && ./build_all_react_native.sh"
   },
   "keywords": [
     "iOS",

--- a/packages/macos/README.md
+++ b/packages/macos/README.md
@@ -11,3 +11,31 @@ npm install @nativescript/macos-node-api
 ## Usage
 
 See [examples](https://github.com/NativeScript/runtime-node-api/tree/main/examples) in the repo. Best run on Node.js for now.
+
+## Contributing
+
+To build `@nativescript/macos-node-api` for yourself:
+
+```sh
+git clone git@github.com:NativeScript/napi-ios.git
+cd napi-ios
+npm install
+
+# This script does the following:
+# 1. Builds the metadata generator, which consists of the following steps:
+#    - Download LLVM
+#    - Inside ./metadata-generator, run cmake to produce:
+#      - ./metadata-generator/dist/arm64/bin/objc-metadata-generator
+#      - ./metadata-generator/dist/x86_64/bin/objc-metadata-generator
+# 2. Generates metadata for iOS and macOS:
+#    - ./metadata-generator/metadata/metadata.ios.arm64.{h,nsmd}
+#    - ./metadata-generator/metadata/metadata.ios-sim.{arm64,x86_64}.{h,nsmd}
+#    - ./metadata-generator/metadata/metadata.macos.{arm64,x86_64}.{h,nsmd}
+# 3. Builds the NativeScript iOS XCFramework:
+#    - ./packages/ios/build/RelWithDebInfo/NativeScript.apple.node
+# 4. Builds the NativeScript macOS XCFramework:
+#    - ./packages/macos/build/RelWithDebInfo/NativeScript.apple.node
+./build_all_react_native.sh
+```
+
+Currently, we are following a convention of committing most, if not all, of these build files to source, so you may find that it's ready set up to begin with.

--- a/packages/macos/package.json
+++ b/packages/macos/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nativescript/macos-node-api",
-  "version": "0.1.4",
+  "version": "0.2.0",
   "description": "An embeddable, engine-agnostic NativeScript runtime for macOS based on Node-API",
   "repository": {
     "type": "git",

--- a/packages/macos/package.json
+++ b/packages/macos/package.json
@@ -17,8 +17,7 @@
   ],
   "scripts": {
     "test": "node ../../examples/foundation.js",
-    "build": "deno task build",
-    "prepublishOnly": "npx rimraf build && npm run build"
+    "build": "cd ../.. && ./build_all_react_native.sh"
   },
   "keywords": [
     "AppKit",


### PR DESCRIPTION
In this PR, I:

- added build/publishing instructions.
- removed the `prepublishOnly` scripts for now.
- bumped both `@nativescript/ios-node-api` and `@nativescript/macos-node-api` to `0.2.0` in preparation for publishing to npm.