### PR TITLE
fix(ffi): use function pointer type for x86_64 objc_msgSend target

### DIFF
--- a/NativeScript/ffi/shared/jsi/NativeApiJsiInvocation.h
+++ b/NativeScript/ffi/shared/jsi/NativeApiJsiInvocation.h
@@ -477,7 +477,7 @@ Value callObjCSelector(Runtime& runtime,
 #if defined(__x86_64__)
     bool isStret = signature->returnType.ffiType->size > 16 &&
                    signature->returnType.ffiType->type == FFI_TYPE_STRUCT;
-    void* target = dispatchSuperClass != Nil
+    void (*target)(void) = dispatchSuperClass != Nil
                        ? (isStret ? FFI_FN(objc_msgSendSuper_stret)
                                   : FFI_FN(objc_msgSendSuper))
                        : (isStret ? FFI_FN(objc_msgSend_stret)


### PR DESCRIPTION
Fixes #47

## Problem

On Xcode 26, x86_64 simulator builds fail when compiling `NativeApiJsiInvocation.h`:

```
error: cannot initialize a variable of type 'void *' with an rvalue of type 'void (*)()'
error: no matching function for call to 'ffi_call'
```

## Solution

In the `__x86_64__` stret dispatch path, change the `target` variable from `void*` to `void (*)(void)` so it matches `ffi_call`'s second parameter and the `FFI_FN()` macro return type.

The arm64 branch already passes `FFI_FN(...)` directly; this aligns the x86_64 branch with the same typing without changing runtime behavior.

Made with [Cursor](https://cursor.com)