### PR TITLE
feat(metadata-generator): JSON emitter with availability and native selectors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,6 +61,7 @@ v8_build
 
 dist
 packages/*/types
+packages/*/metadata-json
 
 SwiftBindgen
 

--- a/NativeScript/ffi/napi/ClassBuilder.mm
+++ b/NativeScript/ffi/napi/ClassBuilder.mm
@@ -582,7 +582,12 @@ std::vector<MethodDescriptor*> ClassBuilder::lookupMethodDescriptors(std::string
   // method in the superclass chain.
   ObjCClass* currentClass = superclass;
   while (currentClass != nullptr) {
-    auto findMethod = currentClass->members.find(name);
+    // JS extend() overrides target instance members; fall back to a static
+    // twin only when no instance member exists under this name.
+    auto findMethod = currentClass->members.find({name, false});
+    if (findMethod == currentClass->members.end()) {
+      findMethod = currentClass->members.find({name, true});
+    }
     if (findMethod != currentClass->members.end()) {
       appendMemberDescriptors(findMethod->second);
       if (!descriptors.empty()) {
@@ -597,7 +602,10 @@ std::vector<MethodDescriptor*> ClassBuilder::lookupMethodDescriptors(std::string
   std::function<void(std::unordered_set<ObjCProtocol*>&)> processProtocols =
       [&](std::unordered_set<ObjCProtocol*>& protocols) {
         for (auto protocol : protocols) {
-          auto findMethod = protocol->members.find(name);
+          auto findMethod = protocol->members.find({name, false});
+          if (findMethod == protocol->members.end()) {
+            findMethod = protocol->members.find({name, true});
+          }
           if (findMethod != protocol->members.end()) {
             appendMemberDescriptors(findMethod->second);
           }
@@ -951,8 +959,7 @@ napi_value ClassBuilder::ExtendCallback(napi_env env, napi_callback_info info) {
     if (existingClass != nullptr) {
       newClassName = nextAvailableClassName(requestedName);
       shouldAliasRequestedName =
-          !class_conformsToProtocol(existingClass,
-                                    @protocol(ObjCBridgeClassBuilderProtocol));
+          !class_conformsToProtocol(existingClass, @protocol(ObjCBridgeClassBuilderProtocol));
     }
   } else {
     newClassName = baseClassNameBuf;

--- a/NativeScript/ffi/napi/ClassMember.h
+++ b/NativeScript/ffi/napi/ClassMember.h
@@ -56,7 +56,29 @@ typedef std::unordered_map<std::string, MethodDescriptor> MethodMap;
 
 class ObjCClassMember;
 
-typedef std::unordered_map<std::string, ObjCClassMember> ObjCClassMemberMap;
+// Static and instance members may share a JS name with different selectors
+// and signatures (e.g. NSEvent.modifierFlags); keying by name alone makes the
+// last-defined variant's selector/cif win for both, so the key must carry
+// staticness.
+struct ObjCClassMemberKey {
+  std::string name;
+  bool isStatic = false;
+
+  bool operator==(const ObjCClassMemberKey& other) const {
+    return isStatic == other.isStatic && name == other.name;
+  }
+};
+
+struct ObjCClassMemberKeyHash {
+  size_t operator()(const ObjCClassMemberKey& key) const {
+    return std::hash<std::string>()(key.name) ^
+           (key.isStatic ? 0x9e3779b97f4a7c15ull : 0);
+  }
+};
+
+typedef std::unordered_map<ObjCClassMemberKey, ObjCClassMember,
+                           ObjCClassMemberKeyHash>
+    ObjCClassMemberMap;
 
 class ObjCClass;
 

--- a/NativeScript/ffi/napi/ClassMember.mm
+++ b/NativeScript/ffi/napi/ClassMember.mm
@@ -11,8 +11,10 @@
 #include <memory>
 #include <optional>
 #include <unordered_set>
-#include "ClassBuilder.h"
+#include "Block.h"
 #include "CallbackThreading.h"
+#include "Class.h"
+#include "ClassBuilder.h"
 #include "Closure.h"
 #include "Interop.h"
 #include "MetadataReader.h"
@@ -20,12 +22,10 @@
 #include "SignatureDispatch.h"
 #include "TypeConv.h"
 #include "Util.h"
-#include "Block.h"
-#include "Class.h"
-#include "runtime/NativeScriptException.h"
 #include "js_native_api.h"
 #include "js_native_api_types.h"
 #include "node_api_util.h"
+#include "runtime/NativeScriptException.h"
 
 namespace nativescript {
 
@@ -101,11 +101,11 @@ void ObjCClassMember::defineMembers(napi_env env, ObjCClassMemberMap& memberMap,
     return hasOwn;
   };
 
-  auto tryGetSuperclassMember = [&](const std::string& name) -> ObjCClassMember* {
+  auto tryGetSuperclassMember = [&](const std::string& name, bool isStatic) -> ObjCClassMember* {
     if (cls == nullptr || cls->superclass == nullptr) {
       return nullptr;
     }
-    auto it = cls->superclass->members.find(name);
+    auto it = cls->superclass->members.find({name, isStatic});
     if (it == cls->superclass->members.end()) {
       return nullptr;
     }
@@ -120,8 +120,9 @@ void ObjCClassMember::defineMembers(napi_env env, ObjCClassMemberMap& memberMap,
     next = (flags & mdMemberNext) != 0;
     offset += sizeof(flags);
 
+    const bool isStaticMember = (flags & mdMemberStatic) != 0;
     napi_value jsObject;
-    if ((flags & mdMemberStatic) != 0) {
+    if (isStaticMember) {
       jsObject = constructor;
     } else {
       jsObject = prototype;
@@ -155,7 +156,7 @@ void ObjCClassMember::defineMembers(napi_env env, ObjCClassMemberMap& memberMap,
       bool hasOwnProperty = hasOwnNamedProperty(jsObject, name);
       bool inheritedProperty = hasProperty && !hasOwnProperty;
 
-      ObjCClassMember* superMember = tryGetSuperclassMember(name);
+      ObjCClassMember* superMember = tryGetSuperclassMember(name, isStaticMember);
 
       if (inheritedProperty && superMember != nullptr && superMember->methodOrGetter.isProperty) {
         bool superReadonly = superMember->setter.selector == nullptr;
@@ -175,11 +176,12 @@ void ObjCClassMember::defineMembers(napi_env env, ObjCClassMemberMap& memberMap,
           !readonly ? sel_registerName(setterSelector) : nullptr,
           getterSignature + bridgeState->metadata->signaturesOffset,
           !readonly ? setterSignature + bridgeState->metadata->signaturesOffset : 0, flags);
-      auto memberIt = memberMap.find(name);
+      auto memberIt = memberMap.find({name, isStaticMember});
       if (memberIt != memberMap.end()) {
         memberIt->second = updatedMember;
       } else {
-        const auto& inserted = memberMap.emplace(name, updatedMember);
+        const auto& inserted =
+            memberMap.emplace(ObjCClassMemberKey{name, isStaticMember}, updatedMember);
         memberIt = inserted.first;
       }
 
@@ -209,7 +211,7 @@ void ObjCClassMember::defineMembers(napi_env env, ObjCClassMemberMap& memberMap,
 
       SEL methodSelector = sel_registerName(selector);
       MDSectionOffset signatureOffset = signature + bridgeState->metadata->signaturesOffset;
-      ObjCClassMember* superMember = tryGetSuperclassMember(name);
+      ObjCClassMember* superMember = tryGetSuperclassMember(name, isStaticMember);
       bool selectorExistsInSuper = false;
       if (superMember != nullptr && !superMember->methodOrGetter.isProperty) {
         selectorExistsInSuper = superMember->methodOrGetter.selector == methodSelector;
@@ -229,7 +231,8 @@ void ObjCClassMember::defineMembers(napi_env env, ObjCClassMemberMap& memberMap,
         continue;
       }
 
-      auto memberIt = memberMap.find(name);
+      const ObjCClassMemberKey memberKey{name, isStaticMember};
+      auto memberIt = memberMap.find(memberKey);
       ObjCClassMember* member = nullptr;
       if (memberIt != memberMap.end()) {
         if (memberIt->second.methodOrGetter.isProperty) {
@@ -241,8 +244,8 @@ void ObjCClassMember::defineMembers(napi_env env, ObjCClassMemberMap& memberMap,
       } else if (inheritedProperty && superMember != nullptr &&
                  !superMember->methodOrGetter.isProperty) {
         const auto& inserted = memberMap.emplace(
-            name, ObjCClassMember(bridgeState, superMember->methodOrGetter.selector,
-                                  superMember->methodOrGetter.signatureOffset, flags));
+            memberKey, ObjCClassMember(bridgeState, superMember->methodOrGetter.selector,
+                                       superMember->methodOrGetter.signatureOffset, flags));
         member = &inserted.first->second;
         for (const auto& overload : superMember->overloads) {
           member->addOverload(overload.method.selector, overload.method.signatureOffset,
@@ -252,7 +255,7 @@ void ObjCClassMember::defineMembers(napi_env env, ObjCClassMemberMap& memberMap,
                             (flags & metagen::mdMemberReturnOwned) != 0 ? 1 : 0);
       } else {
         const auto& inserted = memberMap.emplace(
-            name, ObjCClassMember(bridgeState, methodSelector, signatureOffset, flags));
+            memberKey, ObjCClassMember(bridgeState, methodSelector, signatureOffset, flags));
         member = &inserted.first->second;
       }
 
@@ -779,7 +782,11 @@ ObjCClassMember* findInitializerForArgs(napi_env env, ObjCClassMemberMap* initia
       continue;
     }
 
-    const std::string& memberName = pair.first;
+    // Initializers are instance members by definition.
+    if (pair.first.isStatic) {
+      continue;
+    }
+    const std::string& memberName = pair.first.name;
     if (memberName.rfind("init", 0) != 0) {
       continue;
     }
@@ -1448,9 +1455,8 @@ napi_value ObjCClassMember::jsCall(napi_env env, napi_callback_info cbinfo) {
   return jsCallDirect(env, method, jsThis, actualArgc, stackArgs);
 }
 
-napi_value ObjCClassMember::jsCallDirect(napi_env env, ObjCClassMember* method,
-                                         napi_value jsThis, size_t actualArgc,
-                                         const napi_value* rawCallArgs) {
+napi_value ObjCClassMember::jsCallDirect(napi_env env, ObjCClassMember* method, napi_value jsThis,
+                                         size_t actualArgc, const napi_value* rawCallArgs) {
   if (method == nullptr) {
     napi_throw_error(env, "NativeScriptException", "Missing Objective-C method metadata.");
     return nullptr;
@@ -1503,8 +1509,7 @@ napi_value ObjCClassMember::jsCallDirect(napi_env env, ObjCClassMember* method,
     method->cif = selectedCif;
   }
 
-  if (selectedCif != nullptr && !selectedCif->isVariadic &&
-      selectedCif->argc != actualArgc) {
+  if (selectedCif != nullptr && !selectedCif->isVariadic && selectedCif->argc != actualArgc) {
     Method runtimeMethod = receiverIsClass
                                ? class_getClassMethod(receiverClass, selectedMethod->selector)
                                : class_getInstanceMethod(receiverClass, selectedMethod->selector);
@@ -1667,8 +1672,7 @@ napi_value ObjCClassMember::jsCallDirect(napi_env env, ObjCClassMember* method,
       if (obj != nil) {
         ObjCBridgeState* state = ObjCBridgeState::InstanceData(env);
         if (state != nullptr) {
-          if (napi_value cached = state->findCachedObjectWrapper(env, obj);
-              cached != nullptr) {
+          if (napi_value cached = state->findCachedObjectWrapper(env, obj); cached != nullptr) {
             return cached;
           }
         }
@@ -1692,8 +1696,7 @@ napi_value ObjCClassMember::jsCallDirect(napi_env env, ObjCClassMember* method,
       }
     }
 
-    return cif->returnType->toJS(env, nativeResult,
-                                 method->returnOwned ? kReturnOwned : 0);
+    return cif->returnType->toJS(env, nativeResult, method->returnOwned ? kReturnOwned : 0);
   };
 
   bool usesBlockFallback = false;
@@ -1877,8 +1880,7 @@ napi_value ObjCClassMember::jsGetterDirect(napi_env env, ObjCClassMember* method
     if (obj != nil) {
       ObjCBridgeState* state = ObjCBridgeState::InstanceData(env);
       if (state != nullptr) {
-        if (napi_value cached = state->findCachedObjectWrapper(env, obj);
-            cached != nullptr) {
+        if (napi_value cached = state->findCachedObjectWrapper(env, obj); cached != nullptr) {
           return cached;
         }
       }
@@ -1909,8 +1911,8 @@ napi_value ObjCClassMember::jsSetter(napi_env env, napi_callback_info cbinfo) {
   return jsSetterDirect(env, method, jsThis, argv);
 }
 
-napi_value ObjCClassMember::jsSetterDirect(napi_env env, ObjCClassMember* method,
-                                           napi_value jsThis, napi_value value) {
+napi_value ObjCClassMember::jsSetterDirect(napi_env env, ObjCClassMember* method, napi_value jsThis,
+                                           napi_value value) {
   if (method == nullptr) {
     napi_throw_error(env, "NativeScriptException", "Missing Objective-C setter metadata.");
     return nullptr;

--- a/metadata-generator/CMakeLists.txt
+++ b/metadata-generator/CMakeLists.txt
@@ -39,6 +39,7 @@ set(EXEC_SOURCE_FILES
   src/IR/Record.cpp
   src/IR/TypeSpec.cpp
   src/IR/Variable.cpp
+  src/JSONEmitter/Emitter.cpp
   src/TSEmitter/Class.cpp
   src/TSEmitter/Emitter.cpp
   src/TSEmitter/Enum.cpp

--- a/metadata-generator/include/IR.h
+++ b/metadata-generator/include/IR.h
@@ -105,6 +105,7 @@ class VariableDecl {
   VariableDecl(std::string& framework, const EnumConstDecl& decl);
 
   std::string framework;
+  AvailabilityInfo availability;
 
   std::string name;
   TypeSpec type;
@@ -122,6 +123,7 @@ class EnumDecl {
   EnumDecl(CXCursor cursor);
 
   std::string framework;
+  AvailabilityInfo availability;
 
   std::string name;
   std::vector<EnumConstDecl> constants;
@@ -142,6 +144,7 @@ class StructDecl {
   StructDecl(CXCursor cursor);
 
   std::string framework;
+  AvailabilityInfo availability;
 
   std::string name;
   uint16_t size;
@@ -162,6 +165,7 @@ class UnionDecl {
   UnionDecl(CXCursor cursor);
 
   std::string framework;
+  AvailabilityInfo availability;
 
   std::string name;
   uint16_t size;
@@ -182,6 +186,7 @@ class FunctionDecl {
   FunctionDecl(CXCursor cursor);
 
   std::string framework;
+  AvailabilityInfo availability;
 
   std::string name;
   TypeSpec returnType;
@@ -207,6 +212,8 @@ class MemberDecl {
   // Common
   MemberKind kind;
   std::string name;
+
+  AvailabilityInfo availability;
 
   std::string parentClassName;
   std::string parentProtocolName;
@@ -255,6 +262,7 @@ class ClassDecl {
   void postProcessMembers();
 
   std::string framework;
+  AvailabilityInfo availability;
 
   std::string name;
   std::string runtimeName;
@@ -287,6 +295,7 @@ class ProtocolDecl {
   void postProcessMembers();
 
   std::string framework;
+  AvailabilityInfo availability;
 
   std::string name;
   std::vector<std::string> protocolNames;

--- a/metadata-generator/include/IR.h
+++ b/metadata-generator/include/IR.h
@@ -95,6 +95,7 @@ enum VariableConstEvalKind {
 struct EnumConstDecl {
   std::string name;
   int64_t value;
+  AvailabilityInfo availability;
 };
 
 class VariableDecl {

--- a/metadata-generator/include/JSONEmitter.h
+++ b/metadata-generator/include/JSONEmitter.h
@@ -1,0 +1,35 @@
+#pragma once
+
+#include <string>
+#include <unordered_map>
+
+#include "IR.h"
+
+namespace metagen {
+
+// Emits one <Framework>.json per framework (format
+// "nativescript-metadata-json@1") carrying the metadata the .d.ts corpus
+// cannot express: per-symbol/per-member availability for the target platform
+// and the native ObjC selector behind each JS-munged member name. Consumed by
+// agent-facing tooling (@nativescript/metadata-index) as a sidecar to the
+// TSEmitter output.
+class JSONEmitter {
+ public:
+  JSONEmitter(MetadataFactory& factory, std::string outDir)
+      : outDir(std::move(outDir)), factory(factory) {}
+
+  void write();
+
+  std::string outDir;
+  MetadataFactory& factory;
+
+ private:
+  std::unordered_map<std::string, std::string> buffers;
+
+  std::string& ensureBuffer(const std::string& framework);
+  void writeSymbolHeader(std::string& out, const std::string& name,
+                         const char* kind, const AvailabilityInfo& availability);
+  void writeMembers(std::string& out, std::vector<MemberDecl>& members);
+};
+
+}  // namespace metagen

--- a/metadata-generator/include/Util.h
+++ b/metadata-generator/include/Util.h
@@ -114,6 +114,110 @@ inline const char* platformNameForAvailability(AvailabilityPlatform platform) {
   }
 }
 
+// Populated on IR decls only when a JSON metadata output is requested
+// (-output-json); capturing costs an extra clang availability query per
+// cursor, so default builds skip it.
+inline bool gCaptureAvailability = false;
+
+struct AvailabilityInfo {
+  std::string introduced;
+  std::string deprecated;  // version, or "unversioned" for bare deprecation
+  std::string obsoleted;
+  bool unavailable = false;
+  std::string message;
+
+  bool hasData() const {
+    return unavailable || !introduced.empty() || !deprecated.empty() ||
+           !obsoleted.empty();
+  }
+};
+
+inline std::string formatCXVersion(const CXVersion& version) {
+  // 100000 is Apple's API_TO_BE_DEPRECATED sentinel — an intent marker, not
+  // an actual version; treat it as no data.
+  if (version.Major < 0 || version.Major >= 100000) {
+    return "";
+  }
+  std::string result = std::to_string(version.Major);
+  if (version.Minor >= 0) {
+    result += "." + std::to_string(version.Minor);
+    if (version.Subminor >= 0) {
+      result += "." + std::to_string(version.Subminor);
+    }
+  }
+  return result;
+}
+
+// Availability of a declaration for the current target platform
+// (gAvailabilityPlatform). Unlike isAvailable(), which filters decls out,
+// this captures the version data itself for downstream emitters.
+inline AvailabilityInfo getAvailabilityInfo(CXCursor cursor) {
+  AvailabilityInfo info;
+
+  int alwaysDeprecated = 0;
+  int alwaysUnavailable = 0;
+  CXString deprecatedMessage;
+  CXString unavailableMessage;
+  int availabilityCount = clang_getCursorPlatformAvailability(
+      cursor, &alwaysDeprecated, &deprecatedMessage, &alwaysUnavailable,
+      &unavailableMessage, nullptr, 0);
+  clang_disposeString(deprecatedMessage);
+  clang_disposeString(unavailableMessage);
+
+  if (alwaysUnavailable) {
+    info.unavailable = true;
+  }
+  if (alwaysDeprecated) {
+    info.deprecated = "unversioned";
+  }
+  if (availabilityCount <= 0) {
+    return info;
+  }
+
+  std::vector<CXPlatformAvailability> platformAvailability(
+      static_cast<size_t>(availabilityCount));
+  clang_getCursorPlatformAvailability(
+      cursor, &alwaysDeprecated, &deprecatedMessage, &alwaysUnavailable,
+      &unavailableMessage, platformAvailability.data(), availabilityCount);
+  clang_disposeString(deprecatedMessage);
+  clang_disposeString(unavailableMessage);
+
+  const char* wantedPlatform =
+      platformNameForAvailability(gAvailabilityPlatform);
+  for (auto& item : platformAvailability) {
+    const char* platform = clang_getCString(item.Platform);
+    if (wantedPlatform != nullptr && platform != nullptr &&
+        std::string(platform) == wantedPlatform) {
+      if (item.Unavailable) {
+        info.unavailable = true;
+      }
+      std::string introduced = formatCXVersion(item.Introduced);
+      if (!introduced.empty()) {
+        info.introduced = introduced;
+      }
+      std::string deprecated = formatCXVersion(item.Deprecated);
+      if (!deprecated.empty()) {
+        info.deprecated = deprecated;
+      }
+      std::string obsoleted = formatCXVersion(item.Obsoleted);
+      if (!obsoleted.empty()) {
+        info.obsoleted = obsoleted;
+      }
+      const char* message = clang_getCString(item.Message);
+      if (message != nullptr && message[0] != '\0') {
+        info.message = message;
+      }
+      break;
+    }
+  }
+
+  for (auto& item : platformAvailability) {
+    clang_disposeCXPlatformAvailability(&item);
+  }
+
+  return info;
+}
+
 inline std::string jsifySelector(const std::string& selector) {
   std::string jsifiedSelector;
   jsifiedSelector.reserve(selector.size());

--- a/metadata-generator/include/Util.h
+++ b/metadata-generator/include/Util.h
@@ -14,6 +14,7 @@ namespace metagen {
 enum class AvailabilityPlatform {
   Unknown,
   IOS,
+  MacCatalyst,
   MacOS,
   TvOS,
   WatchOS,
@@ -27,6 +28,8 @@ inline int gAvailabilityTargetMinor = -1;
 
 inline AvailabilityPlatform platformFromTargetTriple(
     const std::string& targetTriple) {
+  if (targetTriple.find("macabi") != std::string::npos)
+    return AvailabilityPlatform::MacCatalyst;
   // Check 'macosx' before 'macos' to avoid partial match; also handle modern
   // 'macos' spelling used in triples like x86_64-apple-macos11.0.
   if (targetTriple.find("macosx") != std::string::npos ||
@@ -101,6 +104,8 @@ inline const char* platformNameForAvailability(AvailabilityPlatform platform) {
   switch (platform) {
     case AvailabilityPlatform::IOS:
       return "ios";
+    case AvailabilityPlatform::MacCatalyst:
+      return "maccatalyst";
     case AvailabilityPlatform::MacOS:
       return "macos";
     case AvailabilityPlatform::TvOS:

--- a/metadata-generator/src/IR/Class.cpp
+++ b/metadata-generator/src/IR/Class.cpp
@@ -8,6 +8,9 @@ namespace metagen {
 
 ClassDecl::ClassDecl(CXCursor cursor) {
   framework = getFrameworkName(cursor);
+  if (gCaptureAvailability) {
+    availability = getAvailabilityInfo(cursor);
+  }
 
   CXString cxname = clang_getCursorSpelling(cursor);
   name = clang_getCString(cxname);

--- a/metadata-generator/src/IR/Enum.cpp
+++ b/metadata-generator/src/IR/Enum.cpp
@@ -120,6 +120,9 @@ EnumDecl::EnumDecl(CXCursor cursor) {
             EnumConstDecl decl;
             decl.name = nameStr;
             decl.value = value;
+            if (gCaptureAvailability) {
+              decl.availability = getAvailabilityInfo(cursor);
+            }
             state->constants.emplace_back(decl);
             break;
           }

--- a/metadata-generator/src/IR/Enum.cpp
+++ b/metadata-generator/src/IR/Enum.cpp
@@ -13,7 +13,7 @@ namespace metagen {
 // - Deferred
 // Basically, split the name into parts (assuming camel case), and then remove
 // the repeating parts from the beginning and end of the name.
-void transformEnumMemberNames(std::vector<EnumConstDecl> &members) {
+void transformEnumMemberNames(std::vector<EnumConstDecl>& members) {
   std::vector<std::vector<std::string>> parts;
   parts.reserve(members.size());
   size_t skip_begin = 0, skip_end = 0;
@@ -88,6 +88,9 @@ void transformEnumMemberNames(std::vector<EnumConstDecl> &members) {
 
 EnumDecl::EnumDecl(CXCursor cursor) {
   framework = getFrameworkName(cursor);
+  if (gCaptureAvailability) {
+    availability = getAvailabilityInfo(cursor);
+  }
 
   CXString cxname = clang_getCursorSpelling(cursor);
   name = clang_getCString(cxname);
@@ -104,40 +107,39 @@ EnumDecl::EnumDecl(CXCursor cursor) {
           return CXChildVisit_Continue;
         }
 
-        auto state = (EnumDecl *)clientData;
+        auto state = (EnumDecl*)clientData;
 
         CXCursorKind kind = clang_getCursorKind(cursor);
 
         switch (kind) {
-        case CXCursor_EnumConstantDecl: {
-          CXString name = clang_getCursorSpelling(cursor);
-          std::string nameStr = clang_getCString(name);
-          clang_disposeString(name);
-          auto value = clang_getEnumConstantDeclValue(cursor);
-          EnumConstDecl decl;
-          decl.name = nameStr;
-          decl.value = value;
-          state->constants.emplace_back(decl);
-          break;
-        }
+          case CXCursor_EnumConstantDecl: {
+            CXString name = clang_getCursorSpelling(cursor);
+            std::string nameStr = clang_getCString(name);
+            clang_disposeString(name);
+            auto value = clang_getEnumConstantDeclValue(cursor);
+            EnumConstDecl decl;
+            decl.name = nameStr;
+            decl.value = value;
+            state->constants.emplace_back(decl);
+            break;
+          }
 
-        default:
-          break;
+          default:
+            break;
         }
 
         return CXChildVisit_Continue;
       },
       this);
 
-  if (!name.empty())
-    transformEnumMemberNames(constants);
+  if (!name.empty()) transformEnumMemberNames(constants);
 }
 
 void MetadataFactory::processEnumRefs() {
   std::unordered_set<std::string> refs;
   refs.swap(referencedEnums);
 
-  for (const std::string &ref : refs) {
+  for (const std::string& ref : refs) {
     if (enums.contains(ref)) {
       continue;
     }
@@ -151,4 +153,4 @@ void MetadataFactory::processEnumRefs() {
   }
 }
 
-} // namespace metagen
+}  // namespace metagen

--- a/metadata-generator/src/IR/Function.cpp
+++ b/metadata-generator/src/IR/Function.cpp
@@ -1,6 +1,7 @@
-#include "IR.h"
 #include <cctype>
 #include <cstring>
+
+#include "IR.h"
 
 namespace {
 
@@ -9,9 +10,10 @@ bool hasOwnershipWord(const std::string& functionName, const char* word) {
   while (pos != std::string::npos) {
     const size_t after = pos + std::strlen(word);
     const unsigned char next =
-        after < functionName.size() ? static_cast<unsigned char>(functionName[after]) : 0;
-    const bool endsWord =
-        after == functionName.size() || !std::islower(next);
+        after < functionName.size()
+            ? static_cast<unsigned char>(functionName[after])
+            : 0;
+    const bool endsWord = after == functionName.size() || !std::islower(next);
     if (endsWord) {
       return true;
     }
@@ -31,6 +33,9 @@ namespace metagen {
 
 FunctionDecl::FunctionDecl(CXCursor cursor) {
   framework = getFrameworkName(cursor);
+  if (gCaptureAvailability) {
+    availability = getAvailabilityInfo(cursor);
+  }
 
   CXString cxname = clang_getCursorSpelling(cursor);
   name = clang_getCString(cxname);
@@ -73,4 +78,4 @@ FunctionDecl::FunctionDecl(CXCursor cursor) {
   isVariadic = clang_Cursor_isVariadic(cursor);
 }
 
-} // namespace metagen
+}  // namespace metagen

--- a/metadata-generator/src/IR/Member.cpp
+++ b/metadata-generator/src/IR/Member.cpp
@@ -1,114 +1,119 @@
+#include <cassert>
+
 #include "IR.h"
 #include "clang-c/Index.h"
-#include <cassert>
 
 namespace metagen {
 
 MemberDecl::MemberDecl(CXCursor cursor,
-                       std::vector<std::string> *classTypeParameters) {
+                       std::vector<std::string>* classTypeParameters) {
   optional = clang_Cursor_isObjCOptional(cursor);
+
+  if (gCaptureAvailability) {
+    availability = getAvailabilityInfo(cursor);
+  }
 
   CXCursorKind cursorKind = clang_getCursorKind(cursor);
 
   switch (cursorKind) {
-  case CXCursor_ObjCClassMethodDecl:
-  case CXCursor_ObjCInstanceMethodDecl: {
-    kind = kMemberMethod;
-    isStatic = cursorKind == CXCursor_ObjCClassMethodDecl;
+    case CXCursor_ObjCClassMethodDecl:
+    case CXCursor_ObjCInstanceMethodDecl: {
+      kind = kMemberMethod;
+      isStatic = cursorKind == CXCursor_ObjCClassMethodDecl;
 
-    CXString cxname = clang_getCursorSpelling(cursor);
-    methodSelector = clang_getCString(cxname);
-    name = jsifySelector(methodSelector);
-    clang_disposeString(cxname);
+      CXString cxname = clang_getCursorSpelling(cursor);
+      methodSelector = clang_getCString(cxname);
+      name = jsifySelector(methodSelector);
+      clang_disposeString(cxname);
 
-    returnOwned = cursorHasReturnsRetainedAttribute(cursor);
+      returnOwned = cursorHasReturnsRetainedAttribute(cursor);
 
-    auto argc = clang_Cursor_getNumArguments(cursor);
-    if (argc > 0) {
-      parameters.reserve(static_cast<size_t>(argc));
-    }
-
-    for (int i = 0; i < argc; i++) {
-      ParameterDecl param;
-      auto arg = clang_Cursor_getArgument(cursor, i);
-      auto argName = clang_getCursorSpelling(arg);
-      param.name = jsifyName(clang_getCString(argName));
-      clang_disposeString(argName);
-      auto argType = clang_getCursorType(arg);
-      param.type = TypeSpec(argType, classTypeParameters);
-      auto cxTypeString = clang_getCursorPrettyPrinted(arg, 0);
-      std::string prettyPrint = clang_getCString(cxTypeString);
-      clang_disposeString(cxTypeString);
-      if (prettyPrint.find("Nullable") != std::string::npos) {
-        param.type.isNullable = true;
+      auto argc = clang_Cursor_getNumArguments(cursor);
+      if (argc > 0) {
+        parameters.reserve(static_cast<size_t>(argc));
       }
-      parameters.emplace_back(std::move(param));
+
+      for (int i = 0; i < argc; i++) {
+        ParameterDecl param;
+        auto arg = clang_Cursor_getArgument(cursor, i);
+        auto argName = clang_getCursorSpelling(arg);
+        param.name = jsifyName(clang_getCString(argName));
+        clang_disposeString(argName);
+        auto argType = clang_getCursorType(arg);
+        param.type = TypeSpec(argType, classTypeParameters);
+        auto cxTypeString = clang_getCursorPrettyPrinted(arg, 0);
+        std::string prettyPrint = clang_getCString(cxTypeString);
+        clang_disposeString(cxTypeString);
+        if (prettyPrint.find("Nullable") != std::string::npos) {
+          param.type.isNullable = true;
+        }
+        parameters.emplace_back(std::move(param));
+      }
+
+      isVariadic = clang_Cursor_isVariadic(cursor);
+
+      if (isStatic && (name.find("alloc") == 0 || name == "new")) {
+        returnType.kind = kTypeInstanceObject;
+        return;
+      }
+
+      if (!isStatic && name.find("init") == 0) {
+        isInit = true;
+        returnType.kind = kTypeInstanceObject;
+        return;
+      }
+
+      returnType =
+          TypeSpec(clang_getCursorResultType(cursor), classTypeParameters);
+
+      auto cxTypeString = clang_getCursorPrettyPrinted(cursor, 0);
+      std::string typeString = clang_getCString(cxTypeString);
+      clang_disposeString(cxTypeString);
+      typeString = typeString.substr(0, typeString.find(")"));
+      if (typeString.find("Nullable") != std::string::npos) {
+        returnType.isNullable = true;
+      }
+
+      break;
     }
 
-    isVariadic = clang_Cursor_isVariadic(cursor);
+    case CXCursor_ObjCPropertyDecl: {
+      kind = kMemberProperty;
 
-    if (isStatic && (name.find("alloc") == 0 || name == "new")) {
-      returnType.kind = kTypeInstanceObject;
-      return;
+      CXString cxname = clang_Cursor_getObjCPropertyGetterName(cursor);
+      getterSelector = clang_getCString(cxname);
+      CXString cxPropertyName = clang_getCursorSpelling(cursor);
+      std::string propertyName = clang_getCString(cxPropertyName);
+      name = jsifyName(propertyName);
+      clang_disposeString(cxname);
+      clang_disposeString(cxPropertyName);
+
+      cxname = clang_Cursor_getObjCPropertySetterName(cursor);
+      setterSelector = clang_getCString(cxname);
+      setterName = jsifySelector(setterSelector);
+      clang_disposeString(cxname);
+
+      auto attrKind = clang_Cursor_getObjCPropertyAttributes(cursor, 0);
+      isReadonly = (attrKind & CXObjCPropertyAttr_readonly) != 0;
+      isStatic = (attrKind & CXObjCPropertyAttr_class) != 0;
+
+      CXType cxtype = clang_getCursorType(cursor);
+      propertyType = TypeSpec(cxtype, classTypeParameters);
+
+      CXString cxTypeString = clang_getCursorPrettyPrinted(cursor, 0);
+      std::string typeString = clang_getCString(cxTypeString);
+      clang_disposeString(cxTypeString);
+
+      if (typeString.find("Nullable") != std::string::npos) {
+        propertyType.isNullable = true;
+      }
+      break;
     }
 
-    if (!isStatic && name.find("init") == 0) {
-      isInit = true;
-      returnType.kind = kTypeInstanceObject;
-      return;
-    }
-
-    returnType =
-        TypeSpec(clang_getCursorResultType(cursor), classTypeParameters);
-
-    auto cxTypeString = clang_getCursorPrettyPrinted(cursor, 0);
-    std::string typeString = clang_getCString(cxTypeString);
-    clang_disposeString(cxTypeString);
-    typeString = typeString.substr(0, typeString.find(")"));
-    if (typeString.find("Nullable") != std::string::npos) {
-      returnType.isNullable = true;
-    }
-
-    break;
-  }
-
-  case CXCursor_ObjCPropertyDecl: {
-    kind = kMemberProperty;
-
-    CXString cxname = clang_Cursor_getObjCPropertyGetterName(cursor);
-    getterSelector = clang_getCString(cxname);
-    CXString cxPropertyName = clang_getCursorSpelling(cursor);
-    std::string propertyName = clang_getCString(cxPropertyName);
-    name = jsifyName(propertyName);
-    clang_disposeString(cxname);
-    clang_disposeString(cxPropertyName);
-
-    cxname = clang_Cursor_getObjCPropertySetterName(cursor);
-    setterSelector = clang_getCString(cxname);
-    setterName = jsifySelector(setterSelector);
-    clang_disposeString(cxname);
-
-    auto attrKind = clang_Cursor_getObjCPropertyAttributes(cursor, 0);
-    isReadonly = (attrKind & CXObjCPropertyAttr_readonly) != 0;
-    isStatic = (attrKind & CXObjCPropertyAttr_class) != 0;
-
-    CXType cxtype = clang_getCursorType(cursor);
-    propertyType = TypeSpec(cxtype, classTypeParameters);
-
-    CXString cxTypeString = clang_getCursorPrettyPrinted(cursor, 0);
-    std::string typeString = clang_getCString(cxTypeString);
-    clang_disposeString(cxTypeString);
-
-    if (typeString.find("Nullable") != std::string::npos) {
-      propertyType.isNullable = true;
-    }
-    break;
-  }
-
-  default:
-    assert(false && "invalid member kind");
-    break;
+    default:
+      assert(false && "invalid member kind");
+      break;
   }
 }
 
-} // namespace metagen
+}  // namespace metagen

--- a/metadata-generator/src/IR/Protocol.cpp
+++ b/metadata-generator/src/IR/Protocol.cpp
@@ -4,6 +4,9 @@ namespace metagen {
 
 ProtocolDecl::ProtocolDecl(CXCursor cursor) {
   framework = getFrameworkName(cursor);
+  if (gCaptureAvailability) {
+    availability = getAvailabilityInfo(cursor);
+  }
 
   CXString cxname = clang_getCursorSpelling(cursor);
   name = clang_getCString(cxname);
@@ -16,30 +19,30 @@ ProtocolDecl::ProtocolDecl(CXCursor cursor) {
           return CXChildVisit_Continue;
         }
 
-        auto protocol = (ProtocolDecl *)clientData;
+        auto protocol = (ProtocolDecl*)clientData;
 
         CXCursorKind kind = clang_getCursorKind(cursor);
 
         switch (kind) {
-        case CXCursor_ObjCProtocolRef: {
-          CXString name = clang_getCursorSpelling(cursor);
-          std::string nameStr = clang_getCString(name);
-          protocol->protocolNames.emplace_back(nameStr);
-          clang_disposeString(name);
-          break;
-        }
+          case CXCursor_ObjCProtocolRef: {
+            CXString name = clang_getCursorSpelling(cursor);
+            std::string nameStr = clang_getCString(name);
+            protocol->protocolNames.emplace_back(nameStr);
+            clang_disposeString(name);
+            break;
+          }
 
-        case CXCursor_ObjCPropertyDecl:
-        case CXCursor_ObjCClassMethodDecl:
-        case CXCursor_ObjCInstanceMethodDecl: {
-          auto member = MemberDecl(cursor);
-          member.parentProtocolName = protocol->name;
-          protocol->members.emplace_back(std::move(member));
-          break;
-        }
+          case CXCursor_ObjCPropertyDecl:
+          case CXCursor_ObjCClassMethodDecl:
+          case CXCursor_ObjCInstanceMethodDecl: {
+            auto member = MemberDecl(cursor);
+            member.parentProtocolName = protocol->name;
+            protocol->members.emplace_back(std::move(member));
+            break;
+          }
 
-        default:
-          break;
+          default:
+            break;
         }
 
         return CXChildVisit_Continue;
@@ -47,8 +50,8 @@ ProtocolDecl::ProtocolDecl(CXCursor cursor) {
       this);
 }
 
-MemberDecl *ProtocolDecl::getMemberNamed(const std::string &name) {
-  for (auto &member : members) {
+MemberDecl* ProtocolDecl::getMemberNamed(const std::string& name) {
+  for (auto& member : members) {
     if (member.name == name) {
       return &member;
     }
@@ -61,7 +64,7 @@ void MetadataFactory::processProtocolRefs() {
     std::unordered_set<std::string> refs;
     refs.swap(referencedProtocols);
 
-    for (const std::string &name : refs) {
+    for (const std::string& name : refs) {
       if (protocols.contains(name)) {
         continue;
       }
@@ -78,18 +81,18 @@ void MetadataFactory::processProtocolRefs() {
 }
 
 void ProtocolDecl::postProcessMembers() {
-  for (MemberDecl &member : members) {
-    for (ClassDecl *cls : implementerRefs) {
+  for (MemberDecl& member : members) {
+    for (ClassDecl* cls : implementerRefs) {
       convertMethodToPropertyIfNeeded(member, cls->getMemberNamed(member.name),
                                       false);
     }
 
-    for (ProtocolDecl *protocol : protocolRefs) {
+    for (ProtocolDecl* protocol : protocolRefs) {
       convertMethodToPropertyIfNeeded(
           member, protocol->getMemberNamed(member.name), true);
     }
 
-    for (ProtocolDecl *protocol : derivedProtocolRefs) {
+    for (ProtocolDecl* protocol : derivedProtocolRefs) {
       convertMethodToPropertyIfNeeded(
           member, protocol->getMemberNamed(member.name), false);
     }
@@ -100,4 +103,4 @@ void ProtocolDecl::postProcessMembers() {
   }
 }
 
-} // namespace metagen
+}  // namespace metagen

--- a/metadata-generator/src/IR/Record.cpp
+++ b/metadata-generator/src/IR/Record.cpp
@@ -1,10 +1,14 @@
-#include "IR.h"
 #include <string>
+
+#include "IR.h"
 
 namespace metagen {
 
 StructDecl::StructDecl(CXCursor cursor) {
   framework = getFrameworkName(cursor);
+  if (gCaptureAvailability) {
+    availability = getAvailabilityInfo(cursor);
+  }
 
   CXString cxname = clang_getCursorSpelling(cursor);
   name = transformStructName(clang_getCString(cxname));
@@ -19,26 +23,26 @@ StructDecl::StructDecl(CXCursor cursor) {
           return CXChildVisit_Continue;
         }
 
-        auto decl = (StructDecl *)clientData;
+        auto decl = (StructDecl*)clientData;
 
         CXCursorKind kind = clang_getCursorKind(cursor);
 
         switch (kind) {
-        case CXCursor_FieldDecl: {
-          StructFieldDecl field;
-          CXString cxName = clang_getCursorSpelling(cursor);
-          field.name = clang_getCString(cxName);
-          clang_disposeString(cxName);
-          auto type = clang_getCursorType(cursor);
-          field.type = TypeSpec(type);
-          field.type.isNullable = true;
-          field.offset = clang_Cursor_getOffsetOfField(cursor) / 8;
-          decl->fields.emplace_back(field);
-          break;
-        }
+          case CXCursor_FieldDecl: {
+            StructFieldDecl field;
+            CXString cxName = clang_getCursorSpelling(cursor);
+            field.name = clang_getCString(cxName);
+            clang_disposeString(cxName);
+            auto type = clang_getCursorType(cursor);
+            field.type = TypeSpec(type);
+            field.type.isNullable = true;
+            field.offset = clang_Cursor_getOffsetOfField(cursor) / 8;
+            decl->fields.emplace_back(field);
+            break;
+          }
 
-        default:
-          break;
+          default:
+            break;
         }
 
         return CXChildVisit_Continue;
@@ -48,6 +52,9 @@ StructDecl::StructDecl(CXCursor cursor) {
 
 UnionDecl::UnionDecl(CXCursor cursor) {
   framework = getFrameworkName(cursor);
+  if (gCaptureAvailability) {
+    availability = getAvailabilityInfo(cursor);
+  }
 
   CXString cxname = clang_getCursorSpelling(cursor);
   name = transformStructName(clang_getCString(cxname));
@@ -62,25 +69,25 @@ UnionDecl::UnionDecl(CXCursor cursor) {
           return CXChildVisit_Continue;
         }
 
-        auto decl = (UnionDecl *)clientData;
+        auto decl = (UnionDecl*)clientData;
 
         CXCursorKind kind = clang_getCursorKind(cursor);
 
         switch (kind) {
-        case CXCursor_FieldDecl: {
-          UnionFieldDecl field;
-          CXString cxName = clang_getCursorSpelling(cursor);
-          field.name = clang_getCString(cxName);
-          clang_disposeString(cxName);
-          auto type = clang_getCursorType(cursor);
-          field.type = TypeSpec(type);
-          field.type.isNullable = true;
-          decl->fields.emplace_back(field);
-          break;
-        }
+          case CXCursor_FieldDecl: {
+            UnionFieldDecl field;
+            CXString cxName = clang_getCursorSpelling(cursor);
+            field.name = clang_getCString(cxName);
+            clang_disposeString(cxName);
+            auto type = clang_getCursorType(cursor);
+            field.type = TypeSpec(type);
+            field.type.isNullable = true;
+            decl->fields.emplace_back(field);
+            break;
+          }
 
-        default:
-          break;
+          default:
+            break;
         }
 
         return CXChildVisit_Continue;
@@ -93,7 +100,7 @@ void MetadataFactory::processRecordRefs() {
     std::unordered_set<std::string> refs;
     refs.swap(referencedRecords);
 
-    for (const std::string &name : refs) {
+    for (const std::string& name : refs) {
       if (unions.contains(name) || structs.contains(name)) {
         continue;
       }
@@ -113,4 +120,4 @@ void MetadataFactory::processRecordRefs() {
   }
 }
 
-} // namespace metagen
+}  // namespace metagen

--- a/metadata-generator/src/IR/Variable.cpp
+++ b/metadata-generator/src/IR/Variable.cpp
@@ -4,6 +4,9 @@ namespace metagen {
 
 VariableDecl::VariableDecl(CXCursor cursor) {
   framework = getFrameworkName(cursor);
+  if (gCaptureAvailability) {
+    availability = getAvailabilityInfo(cursor);
+  }
 
   CXString cxname = clang_getCursorSpelling(cursor);
   name = jsifyName(clang_getCString(cxname));
@@ -18,35 +21,35 @@ VariableDecl::VariableDecl(CXCursor cursor) {
     CXEvalResultKind kind = clang_EvalResult_getKind(result);
 
     switch (kind) {
-    case CXEval_Int: {
-      constEvalI64 = clang_EvalResult_getAsInt(result);
-      constEvalKind = kEvalI64;
-      break;
-    }
+      case CXEval_Int: {
+        constEvalI64 = clang_EvalResult_getAsInt(result);
+        constEvalKind = kEvalI64;
+        break;
+      }
 
-    case CXEval_Float: {
-      constEvalF64 = clang_EvalResult_getAsDouble(result);
-      constEvalKind = kEvalF64;
-      break;
-    }
+      case CXEval_Float: {
+        constEvalF64 = clang_EvalResult_getAsDouble(result);
+        constEvalKind = kEvalF64;
+        break;
+      }
 
-    case CXEval_StrLiteral:
-    case CXEval_ObjCStrLiteral:
-    case CXEval_CFStr: {
-      constEvalString = clang_EvalResult_getAsStr(result);
-      constEvalKind = kEvalString;
-      break;
-    }
+      case CXEval_StrLiteral:
+      case CXEval_ObjCStrLiteral:
+      case CXEval_CFStr: {
+        constEvalString = clang_EvalResult_getAsStr(result);
+        constEvalKind = kEvalString;
+        break;
+      }
 
-    default:
-      break;
+      default:
+        break;
     }
 
     clang_EvalResult_dispose(result);
   }
 }
 
-VariableDecl::VariableDecl(std::string &framework, const EnumConstDecl &decl) {
+VariableDecl::VariableDecl(std::string& framework, const EnumConstDecl& decl) {
   this->framework = framework;
   name = decl.name;
   constEvalI64 = decl.value;
@@ -54,4 +57,4 @@ VariableDecl::VariableDecl(std::string &framework, const EnumConstDecl &decl) {
   type.kind = kTypeI64;
 }
 
-} // namespace metagen
+}  // namespace metagen

--- a/metadata-generator/src/IR/Variable.cpp
+++ b/metadata-generator/src/IR/Variable.cpp
@@ -51,6 +51,7 @@ VariableDecl::VariableDecl(CXCursor cursor) {
 
 VariableDecl::VariableDecl(std::string& framework, const EnumConstDecl& decl) {
   this->framework = framework;
+  availability = decl.availability;
   name = decl.name;
   constEvalI64 = decl.value;
   constEvalKind = kEvalI64;

--- a/metadata-generator/src/JSONEmitter/Emitter.cpp
+++ b/metadata-generator/src/JSONEmitter/Emitter.cpp
@@ -124,7 +124,8 @@ void JSONEmitter::writeMembers(std::string& out,
       out += jsonEscape(selector);
       out += "\"";
     }
-    if (member.kind == kMemberProperty && !member.setterSelector.empty()) {
+    if (member.kind == kMemberProperty && !member.isReadonly &&
+        !member.setterSelector.empty()) {
       out += ",\"setterSelector\":\"";
       out += jsonEscape(member.setterSelector);
       out += "\"";

--- a/metadata-generator/src/JSONEmitter/Emitter.cpp
+++ b/metadata-generator/src/JSONEmitter/Emitter.cpp
@@ -1,0 +1,210 @@
+#include <cstdio>
+#include <filesystem>
+
+#include "JSONEmitter.h"
+
+namespace metagen {
+
+namespace {
+
+std::string jsonEscape(const std::string& value) {
+  std::string out;
+  out.reserve(value.size() + 8);
+  for (char c : value) {
+    switch (c) {
+      case '"':
+        out += "\\\"";
+        break;
+      case '\\':
+        out += "\\\\";
+        break;
+      case '\n':
+        out += "\\n";
+        break;
+      case '\r':
+        out += "\\r";
+        break;
+      case '\t':
+        out += "\\t";
+        break;
+      default:
+        if (static_cast<unsigned char>(c) < 0x20) {
+          char buf[8];
+          std::snprintf(buf, sizeof(buf), "\\u%04x", c);
+          out += buf;
+        } else {
+          out += c;
+        }
+    }
+  }
+  return out;
+}
+
+// Appends `"availability":{...}` (with leading comma) when there is data.
+void appendAvailability(std::string& out, const AvailabilityInfo& info) {
+  if (!info.hasData()) {
+    return;
+  }
+  out += ",\"availability\":{";
+  bool first = true;
+  auto field = [&](const char* key, const std::string& value) {
+    if (value.empty()) return;
+    if (!first) out += ",";
+    first = false;
+    out += "\"";
+    out += key;
+    out += "\":\"";
+    out += jsonEscape(value);
+    out += "\"";
+  };
+  field("introduced", info.introduced);
+  field("deprecated", info.deprecated);
+  field("obsoleted", info.obsoleted);
+  field("message", info.message);
+  if (info.unavailable) {
+    if (!first) out += ",";
+    out += "\"unavailable\":true";
+  }
+  out += "}";
+}
+
+}  // namespace
+
+std::string& JSONEmitter::ensureBuffer(const std::string& framework) {
+  auto [it, inserted] = buffers.try_emplace(framework);
+  if (inserted) {
+    std::string& out = it->second;
+    out += "{\"format\":\"nativescript-metadata-json@1\"";
+    const char* platform = platformNameForAvailability(gAvailabilityPlatform);
+    if (platform != nullptr) {
+      out += ",\"platform\":\"";
+      out += platform;
+      out += "\"";
+    }
+    out += ",\"framework\":\"";
+    out += jsonEscape(framework);
+    out += "\",\"symbols\":[";
+  } else {
+    it->second += ",";
+  }
+  return it->second;
+}
+
+void JSONEmitter::writeSymbolHeader(std::string& out, const std::string& name,
+                                    const char* kind,
+                                    const AvailabilityInfo& availability) {
+  out += "\n{\"name\":\"";
+  out += jsonEscape(name);
+  out += "\",\"kind\":\"";
+  out += kind;
+  out += "\"";
+  appendAvailability(out, availability);
+}
+
+void JSONEmitter::writeMembers(std::string& out,
+                               std::vector<MemberDecl>& members) {
+  bool wroteAny = false;
+  for (auto& member : members) {
+    const std::string& selector = member.kind == kMemberMethod
+                                      ? member.methodSelector
+                                      : member.getterSelector;
+    if (member.name.empty() ||
+        (selector.empty() && !member.availability.hasData())) {
+      continue;
+    }
+    out += wroteAny ? ",\n" : ",\"members\":[\n";
+    wroteAny = true;
+    out += "{\"jsName\":\"";
+    out += jsonEscape(member.name);
+    out += "\",\"kind\":\"";
+    out += member.kind == kMemberMethod ? "method" : "property";
+    out += "\"";
+    if (!selector.empty()) {
+      out += ",\"selector\":\"";
+      out += jsonEscape(selector);
+      out += "\"";
+    }
+    if (member.kind == kMemberProperty && !member.setterSelector.empty()) {
+      out += ",\"setterSelector\":\"";
+      out += jsonEscape(member.setterSelector);
+      out += "\"";
+    }
+    if (member.isStatic) {
+      out += ",\"static\":true";
+    }
+    appendAvailability(out, member.availability);
+    out += "}";
+  }
+  if (wroteAny) {
+    out += "]";
+  }
+}
+
+void JSONEmitter::write() {
+  for (auto& var : factory.variables) {
+    std::string& out = ensureBuffer(var.second.framework);
+    writeSymbolHeader(out, var.second.name, "const", var.second.availability);
+    out += "}";
+  }
+
+  for (auto& enm : factory.enums) {
+    std::string& out = ensureBuffer(enm.second.framework);
+    writeSymbolHeader(out, enm.second.name, "enum", enm.second.availability);
+    out += "}";
+  }
+
+  for (auto& strct : factory.structs) {
+    std::string& out = ensureBuffer(strct.second.framework);
+    writeSymbolHeader(out, strct.second.name, "struct",
+                      strct.second.availability);
+    out += "}";
+  }
+
+  for (auto& un : factory.unions) {
+    std::string& out = ensureBuffer(un.second.framework);
+    writeSymbolHeader(out, un.second.name, "union", un.second.availability);
+    out += "}";
+  }
+
+  for (auto& func : factory.functions) {
+    std::string& out = ensureBuffer(func.framework);
+    writeSymbolHeader(out, func.name, "function", func.availability);
+    out += "}";
+  }
+
+  for (auto& proto : factory.protocols) {
+    std::string& out = ensureBuffer(proto.second.framework);
+    writeSymbolHeader(out, proto.second.name, "protocol",
+                      proto.second.availability);
+    writeMembers(out, proto.second.members);
+    out += "}";
+  }
+
+  for (auto& cls : factory.classes) {
+    if (cls.first.empty()) {
+      continue;
+    }
+    std::string& out = ensureBuffer(cls.second.framework);
+    writeSymbolHeader(out, cls.second.name, "class", cls.second.availability);
+    writeMembers(out, cls.second.members);
+    out += "}";
+  }
+
+  std::error_code dirError;
+  std::filesystem::create_directories(outDir, dirError);
+
+  for (auto& [framework, buffer] : buffers) {
+    buffer += "\n]}\n";
+    std::string path = outDir + "/" + framework + ".json";
+    auto file = std::fopen(path.c_str(), "w");
+    if (file == nullptr) {
+      std::fprintf(stderr, "JSONEmitter: failed to open %s for writing\n",
+                   path.c_str());
+      continue;
+    }
+    std::fwrite(buffer.data(), 1, buffer.size(), file);
+    std::fclose(file);
+  }
+}
+
+}  // namespace metagen

--- a/metadata-generator/src/main.cpp
+++ b/metadata-generator/src/main.cpp
@@ -12,6 +12,7 @@
 #include <vector>
 
 #include "IR.h"
+#include "JSONEmitter.h"
 #include "Metadata.h"
 #include "MetadataWriter.h"
 #include "SignatureDispatchEmitter.h"
@@ -55,6 +56,7 @@ int main(int argc, char** argv) {
   std::string outputBinFile;
   std::string outputSignatureBindingsCppFile;
   std::string outputDtsFolder;
+  std::string outputJsonFolder;
   std::string docSetFile;
   std::string blacklistModulesFile;
   std::string whitelistModulesFile;
@@ -116,6 +118,8 @@ int main(int argc, char** argv) {
       outputSignatureBindingsCppFile = argv[++i];
     } else if (arg == "-output-dts" || arg == "-output-typescript") {
       outputDtsFolder = argv[++i];
+    } else if (arg == "-output-json") {
+      outputJsonFolder = argv[++i];
     } else if (arg == "-docset-path") {
       docSetFile = argv[++i];
     } else if (arg == "-blacklist-modules") {
@@ -145,6 +149,8 @@ int main(int argc, char** argv) {
       outputBinFile = arg.substr(7);
     } else if (arg.find("types=") == 0) {
       outputDtsFolder = arg.substr(6);
+    } else if (arg.find("json=") == 0) {
+      outputJsonFolder = arg.substr(5);
     } else if (arg.find("ts-index-mode=") == 0) {
       tsIndexMode = arg.substr(14);
     } else if (arg.find("ts-index-frameworks=") == 0) {
@@ -257,6 +263,10 @@ int main(int argc, char** argv) {
 
   CXCursor cursor = clang_getTranslationUnitCursor(unit);
 
+  // Must be set before IR construction — availability is captured while
+  // cursors are alive, not at emit time.
+  gCaptureAvailability = !outputJsonFolder.empty();
+
   MetadataFactory factory;
   factory.includePaths = includePaths;
   factory.process(cursor);
@@ -276,6 +286,11 @@ int main(int argc, char** argv) {
     tsOptions.indexFrameworks = tsIndexFrameworks;
     TSEmitter ts(factory, outputDtsFolder, tsOptions);
     ts.write();
+  }
+
+  if (!outputJsonFolder.empty()) {
+    JSONEmitter json(factory, outputJsonFolder);
+    json.write();
   }
 
   if (!outputBinFile.empty()) {

--- a/scripts/metagen.js
+++ b/scripts/metagen.js
@@ -334,6 +334,13 @@ async function main() {
   }
 
   const typesDir = path.resolve(__dirname, "..", "packages", sdkName, "types");
+  const metadataJsonDir = path.resolve(
+    __dirname,
+    "..",
+    "packages",
+    sdkName,
+    "metadata-json",
+  );
   const metadataDir = path.resolve(__dirname, "..", "metadata-generator", "metadata");
   const signatureBindingsPath =
     process.env.NS_SIGNATURE_BINDINGS_CPP_PATH ||
@@ -341,6 +348,7 @@ async function main() {
     path.resolve(__dirname, "..", "NativeScript", "ffi", "napi", "GeneratedSignatureDispatch.inc");
   await fsp.rm(typesDir, { recursive: true, force: true });
   await fsp.mkdir(typesDir, { recursive: true });
+  await fsp.rm(metadataJsonDir, { recursive: true, force: true });
   await fsp.mkdir(metadataDir, { recursive: true });
   await fsp.mkdir(path.dirname(signatureBindingsPath), { recursive: true });
 
@@ -377,6 +385,7 @@ async function main() {
 
     const args = [
       `types=${typesDir}`,
+      `json=${metadataJsonDir}`,
       ...(sdkName === "macos"
         ? [
             "ts-index-mode=frameworks-list",


### PR DESCRIPTION
Adds -output-json/json= emitting per-framework nativescript-metadata-json@1
sidecars (symbol/member availability from clang platform availability, native
ObjC selector spellings) alongside .nsmd and .d.ts. Availability capture is
gated behind the new flag so default builds are unchanged. metagen.js writes
sidecars to packages/<sdk>/metadata-json (gitignored).

Also static and instance members sharing a JS name previously shared one map slot,
so the last-defined variant's selector/signature/cif served both (NSEvent
dual-name crash family; wrong-cif misreads). Key the member map with
staticness, resolve superclass/extend() lookups accordingly, and skip static
entries during initializer resolution.