### PR TITLE
ci: create pack destination before npm pack

### DIFF
--- a/.github/workflows/npm_napi_release.yml
+++ b/.github/workflows/npm_napi_release.yml
@@ -79,10 +79,10 @@ jobs:
         run: ./scripts/build_all_react_native.sh
       - name: Pack @nativescript/ios-node-api
         working-directory: packages/ios-node-api
-        run: npm pack --pack-destination dist
+        run: mkdir -p dist && npm pack --pack-destination dist
       - name: Pack @nativescript/macos-node-api
         working-directory: packages/macos-node-api
-        run: npm pack --pack-destination dist
+        run: mkdir -p dist && npm pack --pack-destination dist
       - name: Upload npm package artifact for @nativescript/ios-node-api
         uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
         with:


### PR DESCRIPTION
The Unknown command: "Node-API"

To see a list of supported npm commands, run:
  npm help workflow has failed at the **Pack** step on every run since #31 switched to `npm pack --pack-destination dist` — npm errors `ENOENT` because nothing creates `packages/*/dist` first (see [run 31289993061](https://github.com/NativeScript/napi-ios/actions/runs/31289993061); the April 22 run after #31 failed the same way). The Build step itself passes — this is purely packaging plumbing.

Fix: `mkdir -p dist` before each pack.

After merging, re-dispatching the workflow from `main` should produce `@nativescript/macos-node-api@0.4.4-next.*` and `@nativescript/ios-node-api@0.4.1-next.*` under the `next` dist-tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)