### PR TITLE
fix(runtime): resolve app entry from ApplicationPath in runMainApplication

### DIFF
--- a/NativeScript/runtime/NativeScript.mm
+++ b/NativeScript/runtime/NativeScript.mm
@@ -1,10 +1,10 @@
 #include "NativeScript.h"
 #include "Runtime.h"
 #include "RuntimeConfig.h"
-#include "runtime/NativeScriptException.h"
 #include "ffi/shared/Tasks.h"
 #include "js_native_api.h"
 #include "jsr.h"
+#include "runtime/NativeScriptException.h"
 
 using namespace nativescript;
 
@@ -33,7 +33,10 @@ std::unique_ptr<Runtime> runtime_;
 }
 
 - (void)runMainApplication {
-  std::string spec = "./app/index.js";
+  // Boot from the application directory so the entry resolves through its
+  // package.json "main" (falling back to index.*) — a literal index.js is not
+  // guaranteed to exist (CLI-built apps ship bundle.js).
+  std::string spec = RuntimeConfig.ApplicationPath;
   try {
     runtime_->RunModule(spec);
   } catch (const NativeScriptException& e) {


### PR DESCRIPTION
runMainApplication hardcoded ./app/index.js, which does not exist in
CLI-built apps (they ship app/bundle.js with package.json main: "bundle").
Boot from the configured application directory instead, so the module
resolver's existing directory handling picks the entry from package.json
main and still falls back to index.* for plain layouts.
---

Found while bringing @nativescript/core up on the ios-quickjs runtime flavor. The seven fixes in this series were validated together on the iOS 26.5 simulator (combined branch: `fix/run-main-application-entry`): a SolidJS + dominative app boots, renders, and runs stably with all of them applied. Each PR is independent and cherry-picked onto main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)