### PR TITLE
fix(quickjs): preserve accessor descriptors from proxy getOwnPropertyDescriptor traps

### DIFF
--- a/NativeScript/napi/quickjs/source/quickjs.c
+++ b/NativeScript/napi/quickjs/source/quickjs.c
@@ -46519,6 +46519,19 @@ static int js_proxy_get_own_property(JSContext *ctx, JSPropertyDescriptor *pdesc
         }
         ret = true;
         if (pdesc) {
+            /* js_obj_to_desc() returns defineProperty-style flags; convert to
+               an own-property descriptor (CompletePropertyDescriptor) so
+               consumers relying on JS_PROP_GETSET see the accessor. */
+            if (result_desc.flags & (JS_PROP_HAS_GET | JS_PROP_HAS_SET)) {
+                result_desc.flags =
+                    (result_desc.flags &
+                     (JS_PROP_CONFIGURABLE | JS_PROP_ENUMERABLE)) |
+                    JS_PROP_GETSET;
+            } else {
+                result_desc.flags &=
+                    (JS_PROP_CONFIGURABLE | JS_PROP_ENUMERABLE |
+                     JS_PROP_WRITABLE);
+            }
             *pdesc = result_desc;
         } else {
             js_free_desc(ctx, &result_desc);


### PR DESCRIPTION
js_proxy_get_own_property stored the js_obj_to_desc() result directly into
*pdesc, but js_obj_to_desc produces defineProperty-style flags
(JS_PROP_HAS_GET/JS_PROP_HAS_SET) while JSPropertyDescriptor consumers test
JS_PROP_GETSET. Any accessor descriptor returned by a Proxy
getOwnPropertyDescriptor trap therefore degraded to {value: undefined},
which broke every metadata-installed property on class prototypes exposed
through the JSI install script's Proxy (UIDevice.currentDevice.systemVersion
returned undefined and @nativescript/core crashed at boot in
NSString.stringWithString). Convert the flags to own-property form
(CompletePropertyDescriptor) before publishing the descriptor.

Reproduces in pure JS, also present in upstream quickjs-ng:
```
  const t = {};
  Object.defineProperty(t, 'x', {configurable: true, get: () => 42});
  const p = new Proxy(t, {getOwnPropertyDescriptor: Reflect.getOwnPropertyDescriptor});
  Object.getOwnPropertyDescriptor(p, 'x')  // was {value: undefined}, now accessor
```

Found while bringing @nativescript/core up on the ios-quickjs runtime flavor. All fixes in this series were validated together on the iOS 26.5 simulator using a SolidJS + dominative app boots, renders, and runs stably with all of them applied. 

Upstream fix is here: https://github.com/quickjs-ng/quickjs/pull/1658