### PR TITLE
fix(ffi): allow assignment over lazy metadata globals

### DIFF
--- a/NativeScript/ffi/quickjs/NativeApiQuickJS.mm
+++ b/NativeScript/ffi/quickjs/NativeApiQuickJS.mm
@@ -56,11 +56,28 @@ static JSValue NativeApiQuickJSLazyGlobalGetter(JSContext* context, JSValueConst
   JSAtom atom = JS_ValueToAtom(context, data[0]);
   if (atom != JS_ATOM_NULL) {
     JS_DefinePropertyValue(context, global, atom, JS_DupValue(context, result),
-                           JS_PROP_CONFIGURABLE);
+                           JS_PROP_CONFIGURABLE | JS_PROP_WRITABLE);
     JS_FreeAtom(context, atom);
   }
   JS_FreeValue(context, global);
   return result;
+}
+
+// Assigning over a lazy global must behave like a plain global assignment
+// (@nativescript/core writes shims such as global.System); replace the
+// accessor with an ordinary writable property instead of throwing
+// "no setter for property".
+static JSValue NativeApiQuickJSLazyGlobalSetter(JSContext* context, JSValueConst, int argc,
+                                                JSValueConst* argv, int, JSValueConst* data) {
+  JSValue global = JS_GetGlobalObject(context);
+  JSAtom atom = JS_ValueToAtom(context, data[0]);
+  if (atom != JS_ATOM_NULL) {
+    JSValue value = argc > 0 ? JS_DupValue(context, argv[0]) : JS_UNDEFINED;
+    JS_DefinePropertyValue(context, global, atom, value, JS_PROP_C_W_E);
+    JS_FreeAtom(context, atom);
+  }
+  JS_FreeValue(context, global);
+  return JS_UNDEFINED;
 }
 
 bool InstallNativeApiEngineLazyGlobal(Runtime& runtime, std::shared_ptr<NativeApiJsiBridge>,
@@ -103,16 +120,18 @@ bool InstallNativeApiEngineLazyGlobal(Runtime& runtime, std::shared_ptr<NativeAp
   }
 
   JSValue getter = JS_NewCFunctionData(context, NativeApiQuickJSLazyGlobalGetter, 0, 0, 2, data);
+  JSValue setter = JS_NewCFunctionData(context, NativeApiQuickJSLazyGlobalSetter, 1, 0, 2, data);
   JS_FreeValue(context, data[0]);
   JS_FreeValue(context, data[1]);
-  if (JS_IsException(getter)) {
+  if (JS_IsException(getter) || JS_IsException(setter)) {
+    JS_FreeValue(context, getter);
+    JS_FreeValue(context, setter);
     JS_FreeAtom(context, atom);
     JS_FreeValue(context, global);
     return false;
   }
 
-  int status =
-      JS_DefinePropertyGetSet(context, global, atom, getter, JS_UNDEFINED, JS_PROP_CONFIGURABLE);
+  int status = JS_DefinePropertyGetSet(context, global, atom, getter, setter, JS_PROP_CONFIGURABLE);
   JS_FreeAtom(context, atom);
   JS_FreeValue(context, global);
   return status >= 0;

--- a/NativeScript/ffi/shared/jsi/NativeApiJsiInstall.h
+++ b/NativeScript/ffi/shared/jsi/NativeApiJsiInstall.h
@@ -1,7 +1,7 @@
 Object CreateNativeApiJSI(Runtime& runtime, const NativeApiJsiConfig& config) {
   auto bridge = std::make_shared<NativeApiJsiBridge>(config);
-  return Object::createFromHostObject(
-      runtime, std::make_shared<NativeApiHostObject>(std::move(bridge)));
+  return Object::createFromHostObject(runtime,
+                                      std::make_shared<NativeApiHostObject>(std::move(bridge)));
 }
 
 void NativeApiJsiWriteSmokeStage(const char* stage) {
@@ -10,10 +10,9 @@ void NativeApiJsiWriteSmokeStage(const char* stage) {
     return;
   }
 
-  NSString* path = [NSTemporaryDirectory()
-      stringByAppendingPathComponent:@"NativeScriptNativeApiSmoke.marker"];
-  NSString* content =
-      [NSString stringWithFormat:@"stage=%s\n", stage != nullptr ? stage : ""];
+  NSString* path =
+      [NSTemporaryDirectory() stringByAppendingPathComponent:@"NativeScriptNativeApiSmoke.marker"];
+  NSString* content = [NSString stringWithFormat:@"stage=%s\n", stage != nullptr ? stage : ""];
   [content writeToFile:path atomically:YES encoding:NSUTF8StringEncoding error:nil];
 }
 
@@ -184,10 +183,22 @@ void InstallNativeApiJsiGlobalSymbols(Runtime& runtime, const char* globalName) 
           Object.defineProperty(globalThis, name, {
             configurable: true,
             enumerable: false,
-            writable: false,
+            writable: true,
             value: value
           });
           return value;
+        },
+        set: function(value) {
+          // Assignment over a lazy global must behave like a plain global
+          // assignment (@nativescript/core writes shims such as
+          // global.System), not throw "no setter for property".
+          cacheGlobal(name, value);
+          Object.defineProperty(globalThis, name, {
+            configurable: true,
+            enumerable: true,
+            writable: true,
+            value: value
+          });
         }
       });
     } catch (_) {
@@ -197,7 +208,7 @@ void InstallNativeApiJsiGlobalSymbols(Runtime& runtime, const char* globalName) 
         Object.defineProperty(globalThis, name, {
           configurable: true,
           enumerable: false,
-          writable: false,
+          writable: true,
           value: value
         });
       }


### PR DESCRIPTION
Lazy globals were installed getter-only (JS_DefinePropertyGetSet with an
undefined setter in the QuickJS engine path, and a get-only accessor in the
shared JSI install script), and the resolved cache was defined non-writable.
Any strict-mode assignment to a global whose name collides with a metadata
symbol threw 'no setter for property' — @nativescript/core does exactly that
in globals/index.js (global.System = ...), so apps died during bootstrap.

Give lazy globals a setter that replaces the accessor with an ordinary
writable property, matching plain global-assignment semantics, and make the
resolved cache writable.

Found while bringing @nativescript/core up on the ios-quickjs runtime flavor. All fixes in this series were validated together on the iOS 26.5 simulator using a SolidJS + dominative app boots, renders, and runs stably with all of them applied. 

🤖 Generated with [Claude Code](https://claude.com/claude-code)