### PR TITLE
fix(ffi): honor derived receivers in native class static allocators

### DIFF
--- a/NativeScript/ffi/shared/jsi/NativeApiJsiInstall.h
+++ b/NativeScript/ffi/shared/jsi/NativeApiJsiInstall.h
@@ -628,6 +628,19 @@ void InstallNativeApiJsiGlobalSymbols(Runtime& runtime, const char* globalName) 
 		    function rememberInstanceClass(instance) {
 		      return rememberClassOnInstance(instance, wrapper || constructable);
 		    }
+		    // Static allocators may be invoked with a TypeScript-derived class as
+		    // the receiver (core does `_super.new.call(this)`); those must
+		    // materialize and allocate the derived Objective-C class, not the base.
+		    function derivedClassWrapper(target) {
+		      if (target && target !== constructable && target !== wrapper &&
+		          typeof target.__nativeApiEnsureClass === 'function') {
+		        var derived = target.__nativeApiEnsureClass();
+		        if (derived && derived !== constructable && derived !== wrapper) {
+		          return derived;
+		        }
+		      }
+		      return undefined;
+		    }
 	    try {
 	      Object.defineProperty(constructable, 'name', {
 	        configurable: true,
@@ -695,6 +708,10 @@ void InstallNativeApiJsiGlobalSymbols(Runtime& runtime, const char* globalName) 
         enumerable: false,
         writable: true,
         value: function() {
+          var derived = derivedClassWrapper(this);
+          if (derived && typeof derived.alloc === 'function') {
+            return rememberClassOnInstance(derived.alloc.apply(derived, arguments), this);
+          }
           return rememberInstanceClass(nativeClass.alloc.apply(nativeClass, arguments));
         }
       });
@@ -708,6 +725,10 @@ void InstallNativeApiJsiGlobalSymbols(Runtime& runtime, const char* globalName) 
         value: function() {
           if (arguments.length !== 0) {
             throw new Error('new does not take arguments; use invoke for an explicit Objective-C selector.');
+          }
+          var derived = derivedClassWrapper(this);
+          if (derived && typeof derived.new === 'function') {
+            return rememberClassOnInstance(derived.new(), this);
           }
           if (typeof nativeClass.alloc !== 'function') {
             throw new Error('Native class cannot be allocated');


### PR DESCRIPTION
@nativescript/core allocates TypeScript-derived native classes via
'_super.new.call(this)' (e.g. NotificationObserver extends NSObject with
ObjCExposedMethods). The base wrapper's 'new' and 'alloc' ignored the
receiver and always allocated the base Objective-C class, so observers were
plain NSObject instances and NSNotificationCenter callouts crashed with
'-[NSObject onReceive]: unrecognized selector'. Redirect to the receiver's
materialized class wrapper when the receiver is a TypeScript-derived native
class constructor.

Found while bringing @nativescript/core up on the ios-quickjs runtime flavor. All fixes in this series were validated together on the iOS 26.5 simulator using a SolidJS + dominative app boots, renders, and runs stably with all of them applied. 

🤖 Generated with [Claude Code](https://claude.com/claude-code)