### PR TITLE
fix(ffi): make native class instanceof checks marshal the real Class

### DIFF
--- a/NativeScript/ffi/shared/jsi/NativeApiJsiInstall.h
+++ b/NativeScript/ffi/shared/jsi/NativeApiJsiInstall.h
@@ -930,8 +930,11 @@ void InstallNativeApiJsiGlobalSymbols(Runtime& runtime, const char* globalName) 
           }
           var expectedName = nativeClass.runtimeName || nativeClass.name;
           try {
+            // Pass the proxied wrapper: the raw constructable carries no
+            // __nativeApiClass, so it does not marshal to the Objective-C
+            // Class and isKindOfClass() misreports.
             if (typeof value.isKindOfClass === 'function' &&
-                value.isKindOfClass(constructable)) {
+                value.isKindOfClass(wrapper || constructable) === true) {
               return true;
             }
           } catch (_) {


### PR DESCRIPTION
Symbol.hasInstance passed the raw constructable to isKindOfClass(), but
only the proxied wrapper resolves __nativeApiClass, so the argument did not
marshal to the Objective-C Class and isKindOfClass() misreported membership
(a UIView tested true for instanceof UIViewController). @nativescript/core
gates child-view-controller mounting on exactly that check, so pages passed
a UIView to addChildViewController and UIKit crashed on parentViewController.
Pass the wrapper and require a strict true result.

Found while bringing @nativescript/core up on the ios-quickjs runtime flavor. All fixes in this series were validated together on the iOS 26.5 simulator using a SolidJS + dominative app boots, renders, and runs stably with all of them applied. 

🤖 Generated with [Claude Code](https://claude.com/claude-code)