### PR TITLE
fix(ffi): route __invokeBase through the host object's selector dispatch

### DIFF
--- a/NativeScript/ffi/shared/jsi/NativeApiJsiClassBuilder.h
+++ b/NativeScript/ffi/shared/jsi/NativeApiJsiClassBuilder.h
@@ -745,8 +745,12 @@ Value invokeNativeApiJsiBaseMethod(
     throw facebook::jsi::JSError(runtime, "__invokeBase receiver is not native.");
   }
 
-  id receiver =
-      receiverObject.getHostObject<NativeApiObjectHostObject>(runtime)->object();
+  // Dispatch through the host object so initializer selectors get their
+  // receiver-consumption bookkeeping (disown + round-trip/expando forget);
+  // calling the raw selector path here leaves dangling ownership of the
+  // placeholder an init consumes (e.g. UIColor.alloc().initWith...).
+  auto hostObject = receiverObject.getHostObject<NativeApiObjectHostObject>(runtime);
+  id receiver = hostObject->object();
   std::string memberName = args[2].asString(runtime).utf8(runtime);
   size_t actualArgc = count - 3;
 
@@ -760,9 +764,8 @@ Value invokeNativeApiJsiBaseMethod(
       if (actualArgc == 0) {
         Class dispatchClass =
             dispatchSuperclassForJsiDerivedReceiver(receiver, baseClass);
-        return callObjCSelector(runtime, bridge, receiver, false,
-                                propertyMember->selectorName, propertyMember,
-                                nullptr, 0, dispatchClass);
+        return hostObject->callObjectSelector(runtime, propertyMember->selectorName,
+                                              propertyMember, nullptr, 0, dispatchClass);
       }
       if (actualArgc == 1 && !propertyMember->setterSelectorName.empty() &&
           !propertyMember->readonly) {
@@ -771,9 +774,8 @@ Value invokeNativeApiJsiBaseMethod(
         NativeApiMember setterMember = *propertyMember;
         setterMember.selectorName = propertyMember->setterSelectorName;
         setterMember.signatureOffset = propertyMember->setterSignatureOffset;
-        return callObjCSelector(runtime, bridge, receiver, false,
-                                setterMember.selectorName, &setterMember,
-                                args + 3, actualArgc, dispatchClass);
+        return hostObject->callObjectSelector(runtime, setterMember.selectorName, &setterMember,
+                                              args + 3, actualArgc, dispatchClass);
       }
     }
   }
@@ -784,6 +786,6 @@ Value invokeNativeApiJsiBaseMethod(
 
   Class dispatchClass =
       dispatchSuperclassForJsiDerivedReceiver(receiver, baseClass);
-  return callObjCSelector(runtime, bridge, receiver, false, member->selectorName,
-                          member, args + 3, actualArgc, dispatchClass);
+  return hostObject->callObjectSelector(runtime, member->selectorName, member, args + 3,
+                                        actualArgc, dispatchClass);
 }


### PR DESCRIPTION
invokeNativeApiJsiBaseMethod called the raw callObjCSelector, bypassing
NativeApiObjectHostObject::callObjectSelector's initializer bookkeeping.
Every prototype-resolved instance call goes through __invokeBase, so
init-family selectors invoked that way (UIColor.alloc().initWith... in
@nativescript/core's Color) consumed their receiver while the wrapper and
the bridge's round-trip/expando maps kept dangling claims — NSZombies
reports '-[UIPlaceholderColor retain]: message sent to deallocated
instance' during the first text draw. Dispatch through the host object so
initializers disown the consumed receiver and forget its cached values.

Found while bringing @nativescript/core up on the ios-quickjs runtime flavor. All fixes in this series were validated together on the iOS 26.5 simulator using a SolidJS + dominative app boots, renders, and runs stably with all of them applied. 

🤖 Generated with [Claude Code](https://claude.com/claude-code)