### PR TITLE
fix(ffi): answer instanceof for TypeScript-derived classes against the derived class

### DIFF
--- a/NativeScript/ffi/shared/jsi/NativeApiJsiInstall.h
+++ b/NativeScript/ffi/shared/jsi/NativeApiJsiInstall.h
@@ -928,6 +928,24 @@ void InstallNativeApiJsiGlobalSymbols(Runtime& runtime, const char* globalName) 
           if (!value || typeof value !== 'object') {
             return false;
           }
+          // `this` is the constructor instanceof was invoked on. A
+          // TypeScript-derived native class inherits this method through the
+          // wrapper prototype chain until it materializes, so membership must
+          // be answered for the DERIVED Objective-C class — and before
+          // materialization no instance of it can exist.
+          try {
+            if (this && this !== constructable && this !== wrapper &&
+                this.__nativeApiTypeScriptState) {
+              var derivedWrapper = this.__nativeApiTypeScriptState.wrapper;
+              if (!derivedWrapper) {
+                return false;
+              }
+              if (derivedWrapper !== constructable && derivedWrapper !== wrapper) {
+                return derivedWrapper[Symbol.hasInstance](value);
+              }
+            }
+          } catch (_) {
+          }
           var expectedName = nativeClass.runtimeName || nativeClass.name;
           try {
             if (typeof value.isKindOfClass === 'function' &&


### PR DESCRIPTION
## What

On the QuickJS (jsi/ffi) runtime flavor, `x instanceof Derived` for a `@NativeClass`-derived class ran the **base** class's membership check until the derived Objective-C class materialized. A TypeScript-derived constructor inherits the base wrapper's `Symbol.hasInstance` through the wrapper prototype chain; the closure captures the base native class, so any instance of the base kind tested true (`UINavigationControllerImpl instanceof IOSHelper.UILayoutViewController` → `true`).

## Impact

`@nativescript/core`'s `setViewControllerView` gates root-view mounting on exactly that check. For an app whose root view is an imperative `Frame` (`Application.run({ create: () => new Frame() })`), the misfire sent core down the layout-controller branch, marshalled the `iOSFrame` JS helper object into `addSubview:` (as `__NSDictionaryM`), and UIKit threw `NSInvalidArgumentException: -[__NSDictionaryM superview]: unrecognized selector` at boot — a hard crash before first render.

## Fix

`Symbol.hasInstance` is called with the constructor `instanceof` was invoked on as `this` (spec: `Call(instOfHandler, target, «V»)`). In the base wrapper's implementation, detect the inherited invocation (`this` is neither this constructable nor its proxy and carries `__nativeApiTypeScriptState`):

- **materialized** → delegate to the derived wrapper's own `hasInstance` (correct `isKindOfClass:` against the derived class)
- **not materialized** → return `false`: no instance of an unmaterialized class can exist

After materialization the TS constructor's prototype is already reset to the derived wrapper, whose own `hasInstance` answers directly, so the new branch only governs the pre-materialization window.

## Validation

Reproduced deterministically with a root-`Frame` NativeScript app on the iOS 26.5 simulator (ios-quickjs build): crash at boot before the fix; app boots, renders, and runs its display-link loop after. A dominative/document-rooted app (no root Frame) was unaffected before and after.

Sibling of #63: that fix marshalled the real Class for the wrapper's own check; this one covers constructors that inherit the check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)