### PR TITLE
fix(runtime): tolerate sandbox-denied parents in exact-case path checks

### DIFF
--- a/NativeScript/runtime/modules/module/ModuleInternal.cpp
+++ b/NativeScript/runtime/modules/module/ModuleInternal.cpp
@@ -15,8 +15,8 @@
 #include <unordered_map>
 #include <unordered_set>
 
-#include "runtime/NativeScriptException.h"
 #include "native_api_util.h"
+#include "runtime/NativeScriptException.h"
 #include "runtime/RuntimeConfig.h"
 #include "runtime/Util.h"
 #include "runtime/modules/node/Node.h"
@@ -173,7 +173,14 @@ bool PathExistsWithExactCase(const std::filesystem::path& path) {
       }
     }
 
-    if (iterEc || !matched) {
+    if (iterEc) {
+      // On device the sandbox forbids enumerating everything above the app
+      // container (/private/var/...), so case verification is only possible
+      // for listable levels; exists() already vouched for the full path.
+      current /= component;
+      continue;
+    }
+    if (!matched) {
       return false;
     }
 


### PR DESCRIPTION
## What

`PathExistsWithExactCase` (ModuleInternal.cpp) verifies each path component by enumerating its parent directory, starting from the filesystem root. On a physical device the sandbox forbids listing everything above the app container (`/private/var/containers/Bundle/...`, `/var/mobile/Containers/Data/...`): the directory iterator errors at the first system-owned level, the helper returns false, and **every module resolution fails with "The specified module does not exist"** — the runtime cannot boot any app on hardware. The simulator never hits it because its containers live under the listable macOS home directory.

## Fix

When a parent cannot be enumerated, trust the `std::filesystem::exists` check that already vouched for the full path and continue the walk. Case verification still applies to every listable level — which covers the app's own bundle content, the case mistakes the check exists to catch (developing on case-insensitive macOS against case-sensitive device filesystems).

## Validation

iPhone 16 Pro (iOS 26.5.2), ios-quickjs flavor: before the fix, boot terminated with `NativeScriptException: The specified module does not exist: <bundle>/app` (and the LiveSync data-container variant of the same path); after, the same app installs, boots, renders, and runs its display-link loop. Simulator behavior unchanged.

First hardware validation of the ios-quickjs runtime flavor; sibling of the #58–#65 series.

🤖 Generated with [Claude Code](https://claude.com/claude-code)